### PR TITLE
Port to 1.17.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ version = "${mod_version}"
 group = "${mod_group}" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "${mod_name}-Forge-${minecraft_version}"
 
-// Mojang ships Java 17 to end users in 1.18+, so your mod should target Java 17.
-java.toolchain.languageVersion = JavaLanguageVersion.of(17)
+// Mojang ships Java 16 to end users in 1.17.1, so your mod should target Java 16.
+java.toolchain.languageVersion = JavaLanguageVersion.of(16)
 
 println "Java: ${System.getProperty 'java.version'}, JVM: ${System.getProperty 'java.vm.version'} (${System.getProperty 'java.vendor'}), Arch: ${System.getProperty 'os.arch'}"
 minecraft {
@@ -54,9 +54,6 @@ minecraft {
             // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels
             property 'forge.logging.console.level', 'debug'
 
-            // Comma-separated list of namespaces to load gametests from. Empty = all namespaces.
-            property 'forge.enabledGameTestNamespaces', mod_id
-
             // These arguments allow for optional authentication with Mojang servers.
             // If you want to authenticate, put these properties in GRADLE_HOME/gradle.properties.
             // By default, this is C:\Users\<your username>\.gradle\gradle.properties on Windows or ~/.gradle/gradle.properties on Linux/MacOS.
@@ -82,22 +79,6 @@ minecraft {
             args '--singleplayer', "yes", '--nogui', "true"
 
             //property 'forge.enabledGameTestNamespaces', mod_id
-
-            mods.create("${mod_id}").source(sourceSets.main)
-        }
-
-        // This run config launches GameTestServer and runs all registered gametests, then exits.
-        // By default, the server will crash when no gametests are provided.
-        // The gametest system is also enabled by default for other run configs under the /test command.
-        gameTestServer {
-            workingDirectory project.file('run')
-
-            property 'forge.logging.markers', 'REGISTRIES'
-            property 'forge.logging.console.level', 'debug'
-
-            args '--singleplayer', "yes", '--nogui', "true"
-
-            property 'forge.enabledGameTestNamespaces', mod_id
 
             mods.create("${mod_id}").source(sourceSets.main)
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project related properties.
-mod_version=2.0.1
+mod_version=1.3.1
 mod_name=Japanese-Emoji-Commands
 mod_id=japaneseemojicommands
 mod_group=dev.tophatcat.japaneseemojicommands
@@ -14,8 +14,8 @@ mod_twitter=https://twitter.com/KiriCattus
 mod_discord=https://discord.tophatcat.dev
 
 # Minecraft and Forge related properties.
-minecraft_version=1.18.2
-forge_version=40.2.0
+minecraft_version=1.17.1
+forge_version=37.1.1
 #Enable or disable access transformers.
 forge_ats_enabled=false
 

--- a/src/main/java/dev/tophatcat/japaneseemojicommands/ClientModLifecycleEvents.java
+++ b/src/main/java/dev/tophatcat/japaneseemojicommands/ClientModLifecycleEvents.java
@@ -1,0 +1,62 @@
+/*
+ * Japanese-Emoji-Commands - https://github.com/tophatcats-mods/japanese-emoji-commands
+ * Copyright (C) 2016-2023 <KiriCattus>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * Specifically version 2.1 of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ */
+package dev.tophatcat.japaneseemojicommands;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Locale;
+
+@Mod.EventBusSubscriber(modid = JapaneseEmojiCommands.MOD_ID,
+    bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+public class ClientModLifecycleEvents {
+    private static final Logger LOGGER = LogManager.getLogger();
+    static final CommandDispatcher<CommandSourceStack> COMMANDS_DISPATCHER = new CommandDispatcher<>();
+
+    @SubscribeEvent
+    public static void onClientSetup(final FMLClientSetupEvent event) {
+        LOGGER.info(JapaneseEmojiCommands.MOD_ID + " starting up");
+
+        // Initialize commands
+        final LiteralArgumentBuilder<CommandSourceStack> emojiCommand = Commands.literal("emoji");
+        for (final EmoticonsEnum value : EmoticonsEnum.values()) {
+            emojiCommand.then(Commands.literal(value.name().toLowerCase(Locale.ROOT)).executes(ctx -> {
+                if (ctx.getSource().getEntity() instanceof final LocalPlayer player) {
+                    player.chat(new TranslatableComponent(value.getTranslationKey()).getString());
+                }
+                return 1;
+            }));
+        }
+
+        // Register commands
+        COMMANDS_DISPATCHER.register(emojiCommand);
+    }
+}

--- a/src/main/java/dev/tophatcat/japaneseemojicommands/JapaneseEmojiCommands.java
+++ b/src/main/java/dev/tophatcat/japaneseemojicommands/JapaneseEmojiCommands.java
@@ -20,20 +20,16 @@
  */
 package dev.tophatcat.japaneseemojicommands;
 
-import com.mojang.logging.LogUtils;
 import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
-import org.slf4j.Logger;
 
 @Mod(JapaneseEmojiCommands.MOD_ID)
 public class JapaneseEmojiCommands {
 
-    private static final Logger LOGGER = LogUtils.getLogger();
     static final String MOD_ID = "japaneseemojicommands";
 
     public JapaneseEmojiCommands() {
-        LOGGER.info(MOD_ID + " starting up");
         ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> "ANY", (remoteVersion, isFromServer) -> true));
     }
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[40,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[37,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license="${mod_license}"
@@ -30,13 +30,6 @@ displayURL="${mod_homepage}" #optional
 #logoFile="examplemod.png" #optional
 # A text field displayed in the mod UI
 authors="KiriCattus, Paint_Ninja" #optional
-# Display Test controls the display for your mod in the server connection screen
-# MATCH_VERSION means that your mod will cause a red X if the versions on client and server differ. This is the default behaviour and should be what you choose if you have server and client elements to your mod.
-# IGNORE_SERVER_VERSION means that your mod will not cause a red X if it's present on the server but not on the client. This is what you should use if you're a server only mod.
-# IGNORE_ALL_VERSION means that your mod will not cause a red X if it's present on the client or the server. This is a special case and should only be used if your mod has no server component.
-# NONE means that no display test is set on your mod. You need to do this yourself, see IExtensionPoint.DisplayTest for more information. You can define any scheme you wish with this value.
-# IMPORTANT NOTE: this is NOT an instruction as to which environments (CLIENT or DEDICATED SERVER) your mod loads on. Your mod should load (and maybe do nothing!) whereever it finds itself.
-displayTest="IGNORE_ALL_VERSION" # MATCH_VERSION is the default if nothing is specified (#optional)
 
 # The description text for the mod (multi line!) (#mandatory)
 description='''
@@ -49,7 +42,7 @@ ${mod_description}
     # Does this dependency have to exist - if not, ordering below must be specified
     mandatory=true #mandatory
     # The version range of the dependency
-    versionRange="[40.2.0,)" #mandatory
+    versionRange="[37.1.1,)" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,8 +1,6 @@
 {
   "pack": {
     "description": "Japanese Emoji Commands resources",
-    "pack_format": 9,
-    "forge:resource_pack_format": 8,
-    "forge:data_pack_format": 9
+    "pack_format": 7
   }
 }


### PR DESCRIPTION
Based on the 1.16.5 and 1.18.2 versions.

Uses `!emoji (name)` syntax similar to the 1.16.5 version.